### PR TITLE
fix: copy workspace file after changing chown

### DIFF
--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -32,9 +32,6 @@ popd
 ### Application specific configuration
 ### Delete if reusing for other projects
 
-
-cp .devcontainer/workspace ../akdc.code-workspace
-
 # clone repos
 pushd ..
 sudo chown vscode:root .
@@ -43,6 +40,9 @@ git clone https://github.com/retaildevcrews/ngsa-app
 git clone https://github.com/retaildevcrews/loderunner
 
 popd
+
+cp .devcontainer/workspace ../akdc.code-workspace
+
 mkdir -p deploy
 cd deploy
 cp -R ../../ngsa/IaC/DevCluster/. .


### PR DESCRIPTION
Relates to #20.

In the PR I've fixed the `cp .devcontainer/workspace ../akdc.code-workspace` command found in `.devcontainer/post-install.sh`, introduced in #15. When you run the devcontainer locally, the user does not have permission to copy files into `/workspaces`. We got around this in #27 by running `chown`. However, the `cp .devcontainer....` command was ran before the ownership change has run.

